### PR TITLE
Environment variable prefix

### DIFF
--- a/parsers/env.go
+++ b/parsers/env.go
@@ -8,7 +8,7 @@ import (
 // EnvParser is a configuration parser
 // which reads from environment variables
 type EnvParser struct {
-	prefix string
+	prefixes []string
 }
 
 // NewEnvParser returns a new EnvParser.
@@ -16,15 +16,14 @@ type EnvParser struct {
 // An EnvParser read environment variables into
 // a configuration
 func NewEnvParser() *EnvParser {
-	return &EnvParser{""}
+	return &EnvParser{}
 }
 
 // NewEnvParserWithPrefix returns a new EnvParser
-// which reads environment variables with a
-// specified prefix
-func NewEnvParserWithPrefix(prefix string) *EnvParser {
-	prefix = strings.ToLower(prefix)
-	return &EnvParser{prefix}
+// which reads environment variables with any of
+// the specified prefixes
+func NewEnvParserWithPrefix(prefixes ...string) *EnvParser {
+	return &EnvParser{prefixes}
 }
 
 // Parse returns environment variables as a map[string]interface{},
@@ -33,20 +32,23 @@ func (p *EnvParser) Parse() (map[string]interface{}, error) {
 	values := make(map[string]interface{})
 
 	for _, v := range os.Environ() {
-		lc := strings.ToLower(v)
-		if p.prefix != "" && !strings.HasPrefix(lc, p.prefix) {
-			continue
+		for _, prefix := range p.prefixes {
+			prefix = strings.ToLower(prefix)
+			lc := strings.ToLower(v)
+			if prefix != "" && !strings.HasPrefix(lc, prefix) {
+				continue
+			}
+
+			kvp := strings.SplitN(v, "=", 2)
+			if len(kvp) != 2 {
+				continue
+			}
+
+			key := strings.Replace(strings.ToLower(strings.TrimSpace(kvp[0])), prefix, "", 1)
+			value := strings.TrimSpace(kvp[1])
+
+			values[key] = value
 		}
-
-		kvp := strings.SplitN(v, "=", 2)
-		if len(kvp) != 2 {
-			continue
-		}
-
-		key := strings.Replace(strings.ToLower(strings.TrimSpace(kvp[0])), p.prefix, "", 1)
-		value := strings.TrimSpace(kvp[1])
-
-		values[key] = value
 	}
 
 	return values, nil

--- a/parsers/env_test.go
+++ b/parsers/env_test.go
@@ -3,17 +3,16 @@ package parsers
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_NewEnvParserWithPrefix(t *testing.T) {
-	prefix := "AbCdEfGh"
-	p := NewEnvParserWithPrefix(prefix)
+	prefixes := []string{"AbCdEfGh", "ijklm"}
+	p := NewEnvParserWithPrefix(prefixes...)
 
-	assert.Equal(t, strings.ToLower(prefix), p.prefix)
+	assert.Equal(t, prefixes, p.prefixes)
 }
 
 func Test_Env_Parse(t *testing.T) {
@@ -25,6 +24,19 @@ func Test_Env_Parse(t *testing.T) {
 	_ = os.Setenv(envvar, expected)
 
 	p := NewEnvParserWithPrefix(prefix)
+	values, err := p.Parse()
+	assert.NoError(t, err)
+
+	assert.Equal(t, expected, values[key])
+}
+
+func Test_Env_Without_Prefix(t *testing.T) {
+	key := "binder"
+	expected := "VAR_VALUE"
+	err := os.Setenv(key, expected)
+	assert.NoError(t, err)
+
+	p := NewEnvParserWithPrefix("")
 	values, err := p.Parse()
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Make environment variable prefix optional, as well as taking a list of multiple prefixes