### PR TITLE
Implement bind mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Example:
 ```go
 package main
 
-import "github.com/ourstudio-se/binder"
+import (
+    "fmt"
+    "github.com/ourstudio-se/binder"
+)
 
 type MyFirst struct {
     KeyOne string `config:"external_key_one"`
@@ -104,7 +107,6 @@ package main
 
 import (
     "fmt"
-    "log"
     "github.com/ourstudio-se/binder"
 )
 
@@ -120,6 +122,29 @@ func main() {
     bnd := binder.New(
         binder.WithFile("../values.conf"),
         binder.WithWatch("../values.conf"))
+    defer bnd.Close()
+
+    var cfg MyConfig
+    bnd.Bind(&cfg)
+
+}
+```
+
+One can specify a `BindMode` when matching a configuration key to a struct tag. Default is case insensitivity, meaning a struct tag `config:"mykey"` will match a configuration key `MyKey`. Pass the value `ModeStrict` to disable this behavior. Example:
+
+```go
+package main
+
+import "github.com/ourstudio-se/binder"
+
+type MyConfig struct {
+    Property string `config:"PROPERTY"`
+}
+
+func main() {
+    bnd := binder.New(
+        binder.WithFile("../values.conf"),
+        binder.WithBindMode(binder.ModeStrict))
     defer bnd.Close()
 
     var cfg MyConfig

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type Parser interface {
 // a custom type.
 type Config struct {
 	parsers []Parser
+	mask    BindMode
 	binders []reflect.Value
 	cache   *Values
 	errch   chan error
@@ -35,6 +36,7 @@ type Config struct {
 // configuration parsers.
 func New(opts ...Option) *Config {
 	c := &Config{}
+	c.mask = DefaultBindMode
 	c.errch = make(chan error, 1)
 
 	for _, opt := range opts {
@@ -184,7 +186,7 @@ func (c *Config) bindValue(elem reflect.Value, tag string) bool {
 }
 
 func (c *Config) bindString(elem reflect.Value, tag string) bool {
-	value, ok := c.cache.Get(tag)
+	value, ok := c.cache.getString(tag, c.mask)
 	if ok {
 		cur := elem.String()
 		elem.SetString(value)
@@ -195,7 +197,7 @@ func (c *Config) bindString(elem reflect.Value, tag string) bool {
 }
 
 func (c *Config) bindStringArray(elem reflect.Value, tag string) bool {
-	value, ok := c.cache.GetStrings(tag)
+	value, ok := c.cache.getStrings(tag, c.mask)
 	if ok {
 		cur := elem.Interface().([]string)
 		elem.Set(reflect.ValueOf(value))
@@ -206,7 +208,7 @@ func (c *Config) bindStringArray(elem reflect.Value, tag string) bool {
 }
 
 func (c *Config) bindInt(elem reflect.Value, tag string) bool {
-	value, ok := c.cache.GetInt(tag)
+	value, ok := c.cache.getInt(tag, c.mask)
 	if ok {
 		cur := elem.Int()
 		elem.SetInt(int64(value))
@@ -217,7 +219,7 @@ func (c *Config) bindInt(elem reflect.Value, tag string) bool {
 }
 
 func (c *Config) bindFloat32(elem reflect.Value, tag string) bool {
-	value, ok := c.cache.GetFloat(tag)
+	value, ok := c.cache.getFloat(tag, c.mask)
 	if ok {
 		cur := elem.Float()
 		elem.SetFloat(value)
@@ -228,7 +230,7 @@ func (c *Config) bindFloat32(elem reflect.Value, tag string) bool {
 }
 
 func (c *Config) bindFloat64(elem reflect.Value, tag string) bool {
-	value, ok := c.cache.GetFloat(tag)
+	value, ok := c.cache.getFloat(tag, c.mask)
 	if ok {
 		cur := elem.Float()
 		elem.SetFloat(value)
@@ -239,7 +241,7 @@ func (c *Config) bindFloat64(elem reflect.Value, tag string) bool {
 }
 
 func (c *Config) bindBool(elem reflect.Value, tag string) bool {
-	value, ok := c.cache.GetBool(tag)
+	value, ok := c.cache.getBool(tag, c.mask)
 	if ok {
 		cur := elem.Bool()
 		elem.SetBool(value)

--- a/config_test.go
+++ b/config_test.go
@@ -154,6 +154,40 @@ func Test_Bind(t *testing.T) {
 	assert.EqualValues(t, []string{"a", "b"}, b4.ValueField)
 }
 
+func Test_BindMode_IgnoreCase(t *testing.T) {
+	expected := "value"
+
+	m := make(map[string]interface{})
+	m["TeSt_KeY"] = expected
+
+	c := New(
+		WithParser(newFakeParser(m)),
+		WithBindMode(ModeIgnoreCase))
+
+	var result struct {
+		TestKey string `config:"test_key"`
+	}
+	c.Bind(&result)
+
+	assert.Equal(t, expected, result.TestKey)
+}
+
+func Test_BindMode_Strict(t *testing.T) {
+	m := make(map[string]interface{})
+	m["TeSt_KeY"] = "value"
+
+	c := New(
+		WithParser(newFakeParser(m)),
+		WithBindMode(ModeStrict))
+
+	var result struct {
+		TestKey string `config:"test_key"`
+	}
+	c.Bind(&result)
+
+	assert.NotEqual(t, "value", result.TestKey)
+}
+
 type fakeRebindParser struct {
 	value string
 }

--- a/mask.go
+++ b/mask.go
@@ -1,0 +1,23 @@
+package binder
+
+// BindMode is used to determine how to bind to
+// a struct tag.
+type BindMode uint8
+
+const (
+	// ModeIgnoreCase allows case insensitivity when
+	// binding configuration keys to struct tag matches.
+	ModeIgnoreCase BindMode = 1
+
+	// ModeStrict requires case sensitivity when binding
+	// configuration keys to struct tag matches.
+	ModeStrict BindMode = 2
+)
+
+// DefaultBindMode is the default set of flags used
+// for struct tag bind mode, and includes ModeIgnoreCase.
+const DefaultBindMode = ModeIgnoreCase
+
+func (po BindMode) has(other BindMode) bool {
+	return po&other != 0
+}

--- a/options.go
+++ b/options.go
@@ -66,3 +66,13 @@ func WithWatch(path string) Option {
 		c.Watch(path)
 	}
 }
+
+// WithBindMode sets a mode which
+// is used when binding configuration values.
+// To restrict from mapping keys with case insensitivity,
+// pass `ModeStrict` as parameter.
+func WithBindMode(po BindMode) Option {
+	return func(c *Config) {
+		c.mask = po
+	}
+}

--- a/parsers/env.go
+++ b/parsers/env.go
@@ -37,9 +37,9 @@ func (p *EnvParser) Parse() (map[string]interface{}, error) {
 
 	for _, v := range os.Environ() {
 		for _, prefix := range p.prefixes {
-			prefix = strings.ToLower(prefix)
 			lc := strings.ToLower(v)
-			if prefix != "" && !strings.HasPrefix(lc, prefix) {
+			lcp := strings.ToLower(prefix)
+			if prefix != "" && !strings.HasPrefix(lc, lcp) {
 				continue
 			}
 
@@ -48,7 +48,7 @@ func (p *EnvParser) Parse() (map[string]interface{}, error) {
 				continue
 			}
 
-			key := strings.Replace(strings.ToLower(strings.TrimSpace(kvp[0])), prefix, "", 1)
+			key := strings.Replace(strings.TrimSpace(kvp[0]), prefix, "", 1)
 			value := strings.TrimSpace(kvp[1])
 
 			values[key] = value

--- a/value.go
+++ b/value.go
@@ -4,11 +4,22 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 )
 
 // Values is a collection of configuration values.
 type Values struct {
 	m map[string]*Value
+}
+
+func (v *Values) getIgnoreCase(key string) *Value {
+	for k, v := range v.m {
+		if strings.EqualFold(key, k) {
+			return v
+		}
+	}
+
+	return nil
 }
 
 // Get returns the value matching the specified key,
@@ -17,6 +28,14 @@ type Values struct {
 // if no such key was found.
 func (v *Values) Get(key string) (string, bool) {
 	return v.m[key].String()
+}
+
+func (v *Values) getString(key string, op BindMode) (string, bool) {
+	if op.has(ModeStrict) {
+		return v.Get(key)
+	}
+
+	return v.getIgnoreCase(key).String()
 }
 
 // GetStrings returns the value matching the specified
@@ -28,12 +47,28 @@ func (v *Values) GetStrings(key string) ([]string, bool) {
 	return v.m[key].StringArray()
 }
 
+func (v *Values) getStrings(key string, op BindMode) ([]string, bool) {
+	if op.has(ModeStrict) {
+		return v.GetStrings(key)
+	}
+
+	return v.getIgnoreCase(key).StringArray()
+}
+
 // GetInt returns the value matching the specified key,
 // as an integer. It returns true as second return
 // value if the specified key exist, or false
 // if no such key was found.
 func (v *Values) GetInt(key string) (int, bool) {
 	return v.m[key].Int()
+}
+
+func (v *Values) getInt(key string, op BindMode) (int, bool) {
+	if op.has(ModeStrict) {
+		return v.GetInt(key)
+	}
+
+	return v.getIgnoreCase(key).Int()
 }
 
 // GetFloat returns the value matching the specified key,
@@ -44,12 +79,28 @@ func (v *Values) GetFloat(key string) (float64, bool) {
 	return v.m[key].Float()
 }
 
+func (v *Values) getFloat(key string, op BindMode) (float64, bool) {
+	if op.has(ModeStrict) {
+		return v.GetFloat(key)
+	}
+
+	return v.getIgnoreCase(key).Float()
+}
+
 // GetBool returns the value matching the specified key,
 // as a boolean. It returns true as second return
 // value if the specified key exist, or false
 // if no such key was found.
 func (v *Values) GetBool(key string) (bool, bool) {
 	return v.m[key].Bool()
+}
+
+func (v *Values) getBool(key string, op BindMode) (bool, bool) {
+	if op.has(ModeStrict) {
+		return v.GetBool(key)
+	}
+
+	return v.getIgnoreCase(key).Bool()
 }
 
 // Value wraps a configuration value.


### PR DESCRIPTION
A bind mode can now be used to enable a looser or stricter mode when
binding configuration keys to a struct tag.